### PR TITLE
remote/client: support token with template RemotePlace

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1606,13 +1606,16 @@ def start_session(
 
 
 def find_role_by_place(config, place):
+    token_role = None
     for role, role_config in config.items():
         resources, _ = target_factory.normalize_config(role_config)
         remote_places = resources.get("RemotePlace", {})
         remote_place = remote_places.get(place)
         if remote_place:
             return role
-    return None
+        if any(remote_place.startswith('+') for remote_place in remote_places.keys()):
+            token_role = role
+    return token_role
 
 
 def find_any_role_with_place(config):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -535,6 +535,52 @@ def test_reservation_custom_config(place, exporter, tmpdir):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+def test_reservation_custom_config_template(place, exporter, tmpdir):
+    p = tmpdir.join("config.yaml")
+    p.write(
+    """
+    targets:
+      test1:
+        role: foo
+        resources:
+          RemotePlace:
+            name: !template $LG_PLACE
+        drivers:
+        - ManualPowerDriver: {}
+    """
+    )
+    env = os.environ.copy()
+    env['LG_PLACE'] = '+'
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} reserve --wait --shell board=bar name=test', env=env) as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        m = re.search(rb"^export LG_TOKEN=(\S+)$", spawn.before.replace(b'\r\n', b'\n'), re.MULTILINE)
+        s = re.search(rb"^Selected role$", spawn.before.replace(b'\r\n', b'\n'), re.MULTILINE)
+        assert m is not None, spawn.before.strip()
+        assert s is None, spawn.before.strip()
+        token = m.group(1)
+
+    env['LG_TOKEN'] = token.decode('ASCII')
+
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} lock', env=env) as spawn:
+        spawn.expect("acquired place test")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} power get', env=env) as spawn:
+        spawn.expect("Selected role test1 from configuration file")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 2, spawn.before.strip()
+
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} release', env=env) as spawn:
+        spawn.expect("released place test")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
 def test_same_name_resources(place, exporter, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-named-match "testhost/Many/NetworkService" "samename"') as spawn:
         spawn.expect(pexpect.EOF)


### PR DESCRIPTION
Taken from here:
https://github.com/labgrid-project/labgrid/pull/1208


Description
Using a template for RemotePlace is very useful to avoid repetition.
This change adds support for token, when LG_PLACE == + or +TOKEN.

      RemotePlace:
        name: !template $LG_PLACE
The role containing the !template $LG_PLACE will be used if no other match is found.

It's a first step, one can imagine supporting more complex patterns like (see https://github.com/labgrid-project/labgrid/issues/1194):

      RemotePlace:
        name: !template "$LG_PLACE-bbb"
        
        
